### PR TITLE
RFC: Define custom scalars in terms of built-in scalars.

### DIFF
--- a/src/language/__tests__/schema-kitchen-sink.graphql
+++ b/src/language/__tests__/schema-kitchen-sink.graphql
@@ -65,6 +65,8 @@ extend union Feed @onUnion
 
 scalar CustomScalar
 
+scalar StringEncodedCustomScalar = String
+
 scalar AnnotatedScalar @onScalar
 
 extend scalar CustomScalar @onScalar

--- a/src/language/__tests__/schema-kitchen-sink.graphql
+++ b/src/language/__tests__/schema-kitchen-sink.graphql
@@ -65,9 +65,9 @@ extend union Feed @onUnion
 
 scalar CustomScalar
 
-scalar StringEncodedCustomScalar = String
-
 scalar AnnotatedScalar @onScalar
+
+scalar StringEncodedCustomScalar as String
 
 extend scalar CustomScalar @onScalar
 

--- a/src/language/__tests__/schema-parser-test.js
+++ b/src/language/__tests__/schema-parser-test.js
@@ -712,6 +712,7 @@ type Hello {
         {
           kind: 'ScalarTypeDefinition',
           name: nameNode('Hello', { start: 7, end: 12 }),
+          type: null,
           directives: [],
           loc: { start: 0, end: 12 },
         },

--- a/src/language/__tests__/schema-parser-test.js
+++ b/src/language/__tests__/schema-parser-test.js
@@ -712,7 +712,6 @@ type Hello {
         {
           kind: 'ScalarTypeDefinition',
           name: nameNode('Hello', { start: 7, end: 12 }),
-          type: null,
           directives: [],
           loc: { start: 0, end: 12 },
         },

--- a/src/language/__tests__/schema-printer-test.js
+++ b/src/language/__tests__/schema-printer-test.js
@@ -111,9 +111,7 @@ describe('Printer', () => {
 
       scalar AnnotatedScalar @onScalar
 
-      scalar StringEncodedCustomScalar = String
-
-      scalar AnnotatedScalar @onScalar
+      scalar StringEncodedCustomScalar as String
 
       extend scalar CustomScalar @onScalar
 

--- a/src/language/__tests__/schema-printer-test.js
+++ b/src/language/__tests__/schema-printer-test.js
@@ -111,6 +111,10 @@ describe('Printer', () => {
 
       scalar AnnotatedScalar @onScalar
 
+      scalar StringEncodedCustomScalar = String
+
+      scalar AnnotatedScalar @onScalar
+
       extend scalar CustomScalar @onScalar
 
       enum Site {

--- a/src/language/ast.js
+++ b/src/language/ast.js
@@ -448,6 +448,7 @@ export type ScalarTypeDefinitionNode = {
   +loc?: Location,
   +description?: StringValueNode,
   +name: NameNode,
+  +type?: NamedTypeNode;
   +directives?: $ReadOnlyArray<DirectiveNode>,
 };
 

--- a/src/language/ast.js
+++ b/src/language/ast.js
@@ -448,7 +448,7 @@ export type ScalarTypeDefinitionNode = {
   +loc?: Location,
   +description?: StringValueNode,
   +name: NameNode,
-  +type?: NamedTypeNode;
+  +type?: NamedTypeNode,
   +directives?: $ReadOnlyArray<DirectiveNode>,
 };
 

--- a/src/language/parser.js
+++ b/src/language/parser.js
@@ -890,18 +890,23 @@ function parseOperationTypeDefinition(
 }
 
 /**
- * ScalarTypeDefinition : Description? scalar Name Directives[Const]?
+ * ScalarTypeDefinition :
+ *   - Description? scalar Name ScalarOfType? Directives[Const]?
+ *
+ * ScalarOfType : = NamedType
  */
 function parseScalarTypeDefinition(lexer: Lexer<*>): ScalarTypeDefinitionNode {
   const start = lexer.token;
   const description = parseDescription(lexer);
   expectKeyword(lexer, 'scalar');
   const name = parseName(lexer);
+  const type = skip(lexer, TokenKind.EQUALS) ? parseNamedType(lexer) : null;
   const directives = parseDirectives(lexer, true);
   return {
     kind: SCALAR_TYPE_DEFINITION,
     description,
     name,
+    type,
     directives,
     loc: loc(lexer, start),
   };

--- a/src/language/parser.js
+++ b/src/language/parser.js
@@ -893,14 +893,17 @@ function parseOperationTypeDefinition(
  * ScalarTypeDefinition :
  *   - Description? scalar Name ScalarOfType? Directives[Const]?
  *
- * ScalarOfType : = NamedType
+ * ScalarOfType : as NamedType
  */
 function parseScalarTypeDefinition(lexer: Lexer<*>): ScalarTypeDefinitionNode {
   const start = lexer.token;
   const description = parseDescription(lexer);
   expectKeyword(lexer, 'scalar');
   const name = parseName(lexer);
-  const type = skip(lexer, TokenKind.EQUALS) ? parseNamedType(lexer) : null;
+  let type;
+  if (skipKeyword(lexer, 'as')) {
+    type = parseNamedType(lexer);
+  }
   const directives = parseDirectives(lexer, true);
   return {
     kind: SCALAR_TYPE_DEFINITION,
@@ -1508,9 +1511,23 @@ function expect(lexer: Lexer<*>, kind: string): Token {
 }
 
 /**
- * If the next token is a keyword with the given value, return that token after
+ * If the next token is a keyword with the given value, return true after
  * advancing the lexer. Otherwise, do not change the parser state and return
  * false.
+ */
+function skipKeyword(lexer: Lexer<*>, value: string): boolean {
+  const token = lexer.token;
+  const match = token.kind === TokenKind.NAME && token.value === value;
+  if (match) {
+    lexer.advance();
+  }
+  return match;
+}
+
+/**
+ * If the next token is a keyword with the given value, return that token after
+ * advancing the lexer. Otherwise, do not change the parser state and throw
+ * an error.
  */
 function expectKeyword(lexer: Lexer<*>, value: string): Token {
   const token = lexer.token;

--- a/src/language/printer.js
+++ b/src/language/printer.js
@@ -112,7 +112,7 @@ const printDocASTReducer = {
 
   ScalarTypeDefinition: ({ description, name, directives }) =>
     join(
-      [description, join(['scalar', name, wrap(' = ', type), join(directives, ' ')], ' ')],
+      [description, join(['scalar', name, wrap(' as ', type), join(directives, ' ')], ' ')],
       '\n',
     ),
 

--- a/src/language/printer.js
+++ b/src/language/printer.js
@@ -110,9 +110,12 @@ const printDocASTReducer = {
 
   OperationTypeDefinition: ({ operation, type }) => operation + ': ' + type,
 
-  ScalarTypeDefinition: ({ description, name, directives }) =>
+  ScalarTypeDefinition: ({ description, name, type, directives }) =>
     join(
-      [description, join(['scalar', name, wrap(' as ', type), join(directives, ' ')], ' ')],
+      [
+        description,
+        join(['scalar', name, wrap('as ', type), join(directives, ' ')], ' '),
+      ],
       '\n',
     ),
 

--- a/src/language/printer.js
+++ b/src/language/printer.js
@@ -112,7 +112,7 @@ const printDocASTReducer = {
 
   ScalarTypeDefinition: ({ description, name, directives }) =>
     join(
-      [description, join(['scalar', name, join(directives, ' ')], ' ')],
+      [description, join(['scalar', name, wrap(' = ', type), join(directives, ' ')], ' ')],
       '\n',
     ),
 

--- a/src/language/visitor.js
+++ b/src/language/visitor.js
@@ -101,7 +101,7 @@ export const QueryDocumentKeys = {
   SchemaDefinition: ['directives', 'operationTypes'],
   OperationTypeDefinition: ['type'],
 
-  ScalarTypeDefinition: ['description', 'name', 'directives'],
+  ScalarTypeDefinition: ['description', 'name', 'type', 'directives'],
   ObjectTypeDefinition: [
     'description',
     'name',

--- a/src/type/__tests__/introspection-test.js
+++ b/src/type/__tests__/introspection-test.js
@@ -1310,7 +1310,7 @@ describe('Introspection', () => {
               description:
                 'Indicates this type is a scalar. ' +
                 '`ofType` may represent how this scalar is serialized.',
-              name: 'SCALAR'
+              name: 'SCALAR',
             },
             {
               description:

--- a/src/type/__tests__/introspection-test.js
+++ b/src/type/__tests__/introspection-test.js
@@ -1307,7 +1307,9 @@ describe('Introspection', () => {
             'An enum describing what kind of type a given `__Type` is.',
           enumValues: [
             {
-              description: 'Indicates this type is a scalar. `ofType` is a valid field.',
+              description:
+                'Indicates this type is a scalar. ' +
+                '`ofType` may represent how this scalar is serialized.',
               name: 'SCALAR'
             },
             {

--- a/src/type/__tests__/introspection-test.js
+++ b/src/type/__tests__/introspection-test.js
@@ -1307,8 +1307,8 @@ describe('Introspection', () => {
             'An enum describing what kind of type a given `__Type` is.',
           enumValues: [
             {
-              description: 'Indicates this type is a scalar.',
-              name: 'SCALAR',
+              description: 'Indicates this type is a scalar. `ofType` is a valid field.',
+              name: 'SCALAR'
             },
             {
               description:

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -461,18 +461,6 @@ export class GraphQLScalarType {
     this.astNode = config.astNode;
     this._scalarConfig = config;
     invariant(typeof config.name === 'string', 'Must provide name.');
-    if (this.ofType) {
-      const ofTypeName = this.ofType.name;
-      invariant(
-        ofTypeName === 'String' ||
-        ofTypeName === 'Int' ||
-        ofTypeName === 'Float' ||
-        ofTypeName === 'Boolean' ||
-        ofTypeName === 'ID',
-        `${this.name} may only be described in terms of a built-in scalar ` +
-        `type. However ${ofTypeName} is not a built-in scalar type.`
-      );
-    }
     invariant(
       typeof config.serialize === 'function',
       `${this.name} must provide "serialize" function. If this custom Scalar ` +
@@ -498,7 +486,8 @@ export class GraphQLScalarType {
 
   // Parses an externally provided value to use as an input.
   parseValue(value: mixed): mixed {
-    const parser = this._scalarConfig.parseValue || (this.ofType && this.ofType.parseValue);
+    const parser =
+      this._scalarConfig.parseValue || (this.ofType && this.ofType.parseValue);
     if (isInvalid(value)) {
       return undefined;
     }
@@ -507,7 +496,9 @@ export class GraphQLScalarType {
 
   // Parses an externally provided literal value to use as an input.
   parseLiteral(valueNode: ValueNode, variables: ?ObjMap<mixed>): mixed {
-    const parser = this._scalarConfig.parseLiteral || (this.ofType && this.ofType.parseLiteral);
+    const parser =
+      this._scalarConfig.parseLiteral ||
+      (this.ofType && this.ofType.parseLiteral);
     return parser
       ? parser(valueNode, variables)
       : valueFromASTUntyped(valueNode, variables);

--- a/src/type/introspection.js
+++ b/src/type/introspection.js
@@ -381,7 +381,7 @@ export const __TypeKind = new GraphQLEnumType({
   values: {
     SCALAR: {
       value: TypeKind.SCALAR,
-      description: 'Indicates this type is a scalar.',
+      description: 'Indicates this type is a scalar. `ofType` is a valid field.',
     },
     OBJECT: {
       value: TypeKind.OBJECT,

--- a/src/type/introspection.js
+++ b/src/type/introspection.js
@@ -207,7 +207,7 @@ export const __Type = new GraphQLObjectType({
     'The fundamental unit of any GraphQL Schema is the type. There are ' +
     'many kinds of types in GraphQL as represented by the `__TypeKind` enum.' +
     '\n\nDepending on the kind of a type, certain fields describe ' +
-    'information about that type. Scalar types provide a name, description' +
+    'information about that type. Scalar types provide a name, description ' +
     'and how they serialize, while Enum types provide their possible values. ' +
     'Object and Interface types provide the fields they describe. Abstract ' +
     'types, Union and Interface, provide the Object types possible ' +

--- a/src/type/introspection.js
+++ b/src/type/introspection.js
@@ -207,8 +207,8 @@ export const __Type = new GraphQLObjectType({
     'The fundamental unit of any GraphQL Schema is the type. There are ' +
     'many kinds of types in GraphQL as represented by the `__TypeKind` enum.' +
     '\n\nDepending on the kind of a type, certain fields describe ' +
-    'information about that type. Scalar types provide no information ' +
-    'beyond a name and description, while Enum types provide their values. ' +
+    'information about that type. Scalar types provide a name, description' +
+    'and how they serialize, while Enum types provide their possible values. ' +
     'Object and Interface types provide the fields they describe. Abstract ' +
     'types, Union and Interface, provide the Object types possible ' +
     'at runtime. List and NonNull types compose other types.',
@@ -381,7 +381,9 @@ export const __TypeKind = new GraphQLEnumType({
   values: {
     SCALAR: {
       value: TypeKind.SCALAR,
-      description: 'Indicates this type is a scalar. `ofType` is a valid field.',
+      description:
+        'Indicates this type is a scalar. ' +
+        '`ofType` may represent how this scalar is serialized.',
     },
     OBJECT: {
       value: TypeKind.OBJECT,

--- a/src/utilities/__tests__/schemaPrinter-test.js
+++ b/src/utilities/__tests__/schemaPrinter-test.js
@@ -498,8 +498,17 @@ describe('Type System Printer', () => {
   });
 
   it('Custom Scalar', () => {
+    const EvenType = new GraphQLScalarType({
+      name: 'Even',
+      ofType: GraphQLInt,
+      serialize(value) {
+        return value % 2 === 1 ? value : null;
+      }
+    });
+
     const OddType = new GraphQLScalarType({
       name: 'Odd',
+      // No ofType in this test case.
       serialize(value) {
         return value % 2 === 1 ? value : null;
       },
@@ -508,6 +517,7 @@ describe('Type System Printer', () => {
     const Root = new GraphQLObjectType({
       name: 'Root',
       fields: {
+        even: { type: EvenType },
         odd: { type: OddType },
       },
     });
@@ -519,12 +529,25 @@ describe('Type System Printer', () => {
         query: Root
       }
 
+<<<<<<< HEAD
       scalar Odd
 
       type Root {
         odd: Odd
       }
     `);
+=======
+scalar Even = Int
+
+scalar Odd
+
+type Root {
+  even: Even
+  odd: Odd
+}
+`
+     );
+>>>>>>> RFC: Define custom scalars in terms of built-in scalars.
   });
 
   it('Enum', () => {
@@ -1018,7 +1041,7 @@ describe('Type System Printer', () => {
 
       # An enum describing what kind of type a given \`__Type\` is.
       enum __TypeKind {
-        # Indicates this type is a scalar.
+        # Indicates this type is a scalar. \`ofType\` is a valid field.
         SCALAR
 
         # Indicates this type is an object. \`fields\` and \`interfaces\` are valid fields.

--- a/src/utilities/__tests__/schemaPrinter-test.js
+++ b/src/utilities/__tests__/schemaPrinter-test.js
@@ -529,25 +529,15 @@ describe('Type System Printer', () => {
         query: Root
       }
 
-<<<<<<< HEAD
+      scalar Even as Int
+
       scalar Odd
 
       type Root {
+        even: Even
         odd: Odd
       }
     `);
-=======
-scalar Even = Int
-
-scalar Odd
-
-type Root {
-  even: Even
-  odd: Odd
-}
-`
-     );
->>>>>>> RFC: Define custom scalars in terms of built-in scalars.
   });
 
   it('Enum', () => {
@@ -1023,10 +1013,10 @@ type Root {
       # types in GraphQL as represented by the \`__TypeKind\` enum.
       #
       # Depending on the kind of a type, certain fields describe information about that
-      # type. Scalar types provide no information beyond a name and description, while
-      # Enum types provide their values. Object and Interface types provide the fields
-      # they describe. Abstract types, Union and Interface, provide the Object types
-      # possible at runtime. List and NonNull types compose other types.
+      # type. Scalar types provide a name, descriptionand how they serialize, while Enum
+      # types provide their possible values. Object and Interface types provide the
+      # fields they describe. Abstract types, Union and Interface, provide the Object
+      # types possible at runtime. List and NonNull types compose other types.
       type __Type {
         kind: __TypeKind!
         name: String
@@ -1041,7 +1031,7 @@ type Root {
 
       # An enum describing what kind of type a given \`__Type\` is.
       enum __TypeKind {
-        # Indicates this type is a scalar. \`ofType\` is a valid field.
+        # Indicates this type is a scalar. \`ofType\` may represent how this scalar is serialized.
         SCALAR
 
         # Indicates this type is an object. \`fields\` and \`interfaces\` are valid fields.

--- a/src/utilities/__tests__/schemaPrinter-test.js
+++ b/src/utilities/__tests__/schemaPrinter-test.js
@@ -503,7 +503,7 @@ describe('Type System Printer', () => {
       ofType: GraphQLInt,
       serialize(value) {
         return value % 2 === 1 ? value : null;
-      }
+      },
     });
 
     const OddType = new GraphQLScalarType({
@@ -793,10 +793,10 @@ describe('Type System Printer', () => {
       types in GraphQL as represented by the \`__TypeKind\` enum.
 
       Depending on the kind of a type, certain fields describe information about that
-      type. Scalar types provide no information beyond a name and description, while
-      Enum types provide their values. Object and Interface types provide the fields
-      they describe. Abstract types, Union and Interface, provide the Object types
-      possible at runtime. List and NonNull types compose other types.
+      type. Scalar types provide a name, description and how they serialize, while
+      Enum types provide their possible values. Object and Interface types provide the
+      fields they describe. Abstract types, Union and Interface, provide the Object
+      types possible at runtime. List and NonNull types compose other types.
       """
       type __Type {
         kind: __TypeKind!
@@ -812,7 +812,9 @@ describe('Type System Printer', () => {
 
       """An enum describing what kind of type a given \`__Type\` is."""
       enum __TypeKind {
-        """Indicates this type is a scalar."""
+        """
+        Indicates this type is a scalar. \`ofType\` may represent how this scalar is serialized.
+        """
         SCALAR
 
         """
@@ -1013,8 +1015,8 @@ describe('Type System Printer', () => {
       # types in GraphQL as represented by the \`__TypeKind\` enum.
       #
       # Depending on the kind of a type, certain fields describe information about that
-      # type. Scalar types provide a name, descriptionand how they serialize, while Enum
-      # types provide their possible values. Object and Interface types provide the
+      # type. Scalar types provide a name, description and how they serialize, while
+      # Enum types provide their possible values. Object and Interface types provide the
       # fields they describe. Abstract types, Union and Interface, provide the Object
       # types possible at runtime. List and NonNull types compose other types.
       type __Type {

--- a/src/utilities/buildASTSchema.js
+++ b/src/utilities/buildASTSchema.js
@@ -442,6 +442,7 @@ export class ASTDefinitionBuilder {
     return new GraphQLScalarType({
       name: def.name.value,
       description: getDescription(def, this._options),
+      ofType: def.type && this.buildType(def.type),
       astNode: def,
       serialize: value => value,
     });

--- a/src/utilities/buildASTSchema.js
+++ b/src/utilities/buildASTSchema.js
@@ -442,7 +442,10 @@ export class ASTDefinitionBuilder {
     return new GraphQLScalarType({
       name: def.name.value,
       description: getDescription(def, this._options),
-      ofType: def.type && this.buildType(def.type),
+      // Note: While this could make assertions to get the correctly typed
+      // values below, that would throw immediately while type system
+      // validation with validateSchema() will produce more actionable results.
+      ofType: def.type && (this.buildType(def.type): any),
       astNode: def,
       serialize: value => value,
     });

--- a/src/utilities/buildClientSchema.js
+++ b/src/utilities/buildClientSchema.js
@@ -208,9 +208,13 @@ export function buildClientSchema(
   function buildScalarDef(
     scalarIntrospection: IntrospectionScalarType,
   ): GraphQLScalarType {
+    const ofType = scalarIntrospection.ofType ?
+      getType(scalarIntrospection.ofType) :
+      undefined;
     return new GraphQLScalarType({
       name: scalarIntrospection.name,
       description: scalarIntrospection.description,
+      ofType,
       serialize: value => value,
     });
   }

--- a/src/utilities/buildClientSchema.js
+++ b/src/utilities/buildClientSchema.js
@@ -208,9 +208,9 @@ export function buildClientSchema(
   function buildScalarDef(
     scalarIntrospection: IntrospectionScalarType,
   ): GraphQLScalarType {
-    const ofType = scalarIntrospection.ofType ?
-      getType(scalarIntrospection.ofType) :
-      undefined;
+    const ofType = scalarIntrospection.ofType
+      ? (getType(scalarIntrospection.ofType): any)
+      : undefined;
     return new GraphQLScalarType({
       name: scalarIntrospection.name,
       description: scalarIntrospection.description,

--- a/src/utilities/findBreakingChanges.js
+++ b/src/utilities/findBreakingChanges.js
@@ -161,6 +161,20 @@ export function findTypesThatChangedKind(
           `${typeName} changed from ` +
           `${typeKindName(oldType)} to ${typeKindName(newType)}.`,
       });
+    } else if (
+      oldType instanceof GraphQLScalarType &&
+      newType instanceof GraphQLScalarType
+    ) {
+      const oldOfType = oldType.ofType;
+      const newOfType = newType.ofType;
+      if (oldOfType && newOfType && oldOfType !== newOfType) {
+        breakingChanges.push({
+          type: BreakingChangeType.TYPE_CHANGED_KIND,
+          description: `${typeName} changed from ` +
+            `${typeKindName(oldType)} serialized as ${oldOfType.name} ` +
+            `to ${typeKindName(newType)} serialized as ${newOfType.name}.`
+        });
+      }
     }
   });
   return breakingChanges;

--- a/src/utilities/findBreakingChanges.js
+++ b/src/utilities/findBreakingChanges.js
@@ -161,18 +161,16 @@ export function findTypesThatChangedKind(
           `${typeName} changed from ` +
           `${typeKindName(oldType)} to ${typeKindName(newType)}.`,
       });
-    } else if (
-      oldType instanceof GraphQLScalarType &&
-      newType instanceof GraphQLScalarType
-    ) {
+    } else if (isScalarType(oldType) && isScalarType(newType)) {
       const oldOfType = oldType.ofType;
       const newOfType = newType.ofType;
       if (oldOfType && newOfType && oldOfType !== newOfType) {
         breakingChanges.push({
           type: BreakingChangeType.TYPE_CHANGED_KIND,
-          description: `${typeName} changed from ` +
+          description:
+            `${typeName} changed from ` +
             `${typeKindName(oldType)} serialized as ${oldOfType.name} ` +
-            `to ${typeKindName(newType)} serialized as ${newOfType.name}.`
+            `to ${typeKindName(newType)} serialized as ${newOfType.name}.`,
         });
       }
     }

--- a/src/utilities/introspectionQuery.js
+++ b/src/utilities/introspectionQuery.js
@@ -150,6 +150,7 @@ export type IntrospectionScalarType = {
   +kind: 'SCALAR',
   +name: string,
   +description?: ?string,
+  +ofType?: ?IntrospectionNamedTypeRef<IntrospectionScalarType>,
 };
 
 export type IntrospectionObjectType = {

--- a/src/utilities/schemaPrinter.js
+++ b/src/utilities/schemaPrinter.js
@@ -170,7 +170,7 @@ export function printType(type: GraphQLNamedType, options?: Options): string {
 }
 
 function printScalar(type: GraphQLScalarType, options): string {
-  const ofType = type.ofType ? ` = ${type.ofType.name}` : '';
+  const ofType = type.ofType ? ` as ${type.ofType.name}` : '';
   return printDescription(options, type) + `scalar ${type.name}${ofType}`;
 }
 

--- a/src/utilities/schemaPrinter.js
+++ b/src/utilities/schemaPrinter.js
@@ -170,7 +170,8 @@ export function printType(type: GraphQLNamedType, options?: Options): string {
 }
 
 function printScalar(type: GraphQLScalarType, options): string {
-  return printDescription(options, type) + `scalar ${type.name}`;
+  const ofType = type.ofType ? ` = ${type.ofType.name}` : '';
+  return printDescription(options, type) + `scalar ${type.name}${ofType}`;
 }
 
 function printObject(type: GraphQLObjectType, options): string {


### PR DESCRIPTION
#914 Issue by __leebyron__

This proposes an additive change which allows custom scalars to be defined in terms of the built-in scalars. The motivation is for client-side code generators to understand how to map between the GraphQL type system and a native type system. As an example, a `URL` custom type may be defined in terms of the built-in scalar `String`. It could define additional serialization and parsing logic, however client tools can know to treat `URL` values as `String`. Presently, we do this by defining these mappings manually on the client, which is difficult to scale, or by giving up and making no assumptions of how the custom types serialize.

Another real use case of giving client tools this information is GraphiQL: this change will allow GraphiQL to show more useful errors when a literal of an incorrect kind is provided to a custom scalar. Currently GraphiQL simply accepts all values.

To accomplish this, this proposes adding the following:

* A new property when defining `GraphQLScalarType` (`ofType`) which asserts that only built-in scalar types are provided.

* A second type coercion to guarantee to a client that the serialized values match the `ofType`.

* Delegating the `parseLiteral` and `parseValue` functions to those in `ofType` (this enables downstream validation / GraphiQL features)

* Exposing `ofType` in the introspection system, and consuming that introspection in `buildClientSchema`.

* Adding optional syntax to the SDL, and consuming that in `buildASTSchema` and `extendSchema` as well as in `schemaPrinter`.

* Adding a case to `findBreakingChanges` which looks for a scalar's ofType changing.